### PR TITLE
Ensure fresh Captchas are served by sorting on attempted count

### DIFF
--- a/src/main/java/lc/misc/HelperFunctions.java
+++ b/src/main/java/lc/misc/HelperFunctions.java
@@ -11,10 +11,10 @@ public class HelperFunctions {
         RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
   }
 
-  public static final String safeAlphabets = "ABCDEFGHJKMNOPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-  public static final String allAlphabets = safeAlphabets + "ILl";
+  public static final String safeAlphabets = "ABCDEFGHJKMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  public static final String allAlphabets = safeAlphabets + "ILlO";
   public static final String safeNumbers = "23456789";
-  public static final String allNumbers = safeNumbers + "1";
+  public static final String allNumbers = safeNumbers + "10";
   public static final String specialCharacters = "$#%@&?";
   public static final String safeCharacters = safeAlphabets + safeNumbers + specialCharacters;
 

--- a/src/main/scala/lc/core/captcha.scala
+++ b/src/main/scala/lc/core/captcha.scala
@@ -96,7 +96,7 @@ object Captcha {
       token match {
         case Some(value) => {
           val uuid = getUUID(value)
-          updateAttempted(uuid)
+          updateAttempted(value)
           Right(Id(uuid))
         }
         case None => {
@@ -121,9 +121,9 @@ object Captcha {
     }
   }
 
-  private def updateAttempted(uuid: String): Unit = {
+  private def updateAttempted(token: Int): Unit = {
     val updateAttemptedPstmt = Statements.tlStmts.get.updateAttemptedPstmt
-    updateAttemptedPstmt.setString(1, uuid)
+    updateAttemptedPstmt.setInt(1, token)
     updateAttemptedPstmt.executeUpdate()
   }
 

--- a/src/main/scala/lc/database/statements.scala
+++ b/src/main/scala/lc/database/statements.scala
@@ -19,7 +19,10 @@ class Statements(dbConn: DBConn, maxAttempts: Int) {
       "contentInput varchar, " +
       "image blob, " +
       "attempted int default 0, " +
-      "PRIMARY KEY(token))"
+      "PRIMARY KEY(token));" +
+      """
+      CREATE INDEX IF NOT EXISTS attempted ON challenge(attempted);
+      """
   )
   stmt.execute(
     "CREATE TABLE IF NOT EXISTS mapId" +
@@ -69,13 +72,13 @@ class Statements(dbConn: DBConn, maxAttempts: Int) {
 
   val tokenPstmt: PreparedStatement = dbConn.con.prepareStatement(
     s"""
-      SELECT token
+      SELECT token, attempted
         FROM challenge
         WHERE attempted < $maxAttempts AND
         contentLevel = ? AND
         contentType = ? AND
         contentInput = ?
-        ORDER BY RAND() LIMIT 1"""
+        ORDER BY attempted ASC LIMIT 1"""
   )
 
   val deleteAnswerPstmt: PreparedStatement = dbConn.con.prepareStatement(

--- a/src/main/scala/lc/database/statements.scala
+++ b/src/main/scala/lc/database/statements.scala
@@ -64,10 +64,7 @@ class Statements(dbConn: DBConn, maxAttempts: Int) {
   val updateAttemptedPstmt: PreparedStatement = dbConn.con.prepareStatement(
     "UPDATE challenge " +
       "SET attempted = attempted+1 " +
-      "WHERE token = (SELECT m.token " +
-      "FROM mapId m, challenge c " +
-      "WHERE m.token=c.token AND " +
-      "m.uuid = ?)"
+      "WHERE token = ?;"
   )
 
   val tokenPstmt: PreparedStatement = dbConn.con.prepareStatement(


### PR DESCRIPTION
* create an index on `attempted` column
* order by `attempted` column when finding a new challenge. `order by random` doesn't seem to be working
* optimise update of `attempted` count, by avoiding a table lookup.
* Off-topic: Remove letter 'O' from set of safe alphabets, as it conflicts with number `0`