### PR TITLE
CORS configuration and disable playground

### DIFF
--- a/src/main/scala/lc/Main.scala
+++ b/src/main/scala/lc/Main.scala
@@ -16,7 +16,7 @@ object LCFramework {
     val captcha = new Captcha(config = config, captchaProviders = captchaProviders)
     val backgroundTask = new BackgroundTask(config = config, captcha = captcha)
     backgroundTask.beginThread(delay = config.threadDelay)
-    val server = new Server(address = config.address, port = config.port, captcha = captcha)
+    val server = new Server(address = config.address, port = config.port, captcha = captcha, playgroundEnabled = config.playgroundEnabled, corsHeader = config.corsHeader)
     server.start()
   }
 }

--- a/src/main/scala/lc/core/captchaFields.scala
+++ b/src/main/scala/lc/core/captchaFields.scala
@@ -23,6 +23,8 @@ object AttributesEnum extends Enumeration {
   val CAPTCHA_EXPIRY_TIME_LIMIT: Value = Value("captchaExpiryTimeLimit")
   val THROTTLE: Value = Value("throttle")
   val THREAD_DELAY: Value = Value("threadDelay")
+  val PLAYGROUND_ENABLED: Value = Value("playgroundEnabled")
+  val CORS_HEADER: Value = Value("corsHeader")
   val CONFIG: Value = Value("config")
 }
 

--- a/src/main/scala/lc/core/config.scala
+++ b/src/main/scala/lc/core/config.scala
@@ -45,6 +45,8 @@ class Config(configFilePath: String) {
   val seed: Int = (configJson \ AttributesEnum.RANDOM_SEED.toString).extract[Int]
   val captchaExpiryTimeLimit: Int = (configJson \ AttributesEnum.CAPTCHA_EXPIRY_TIME_LIMIT.toString).extract[Int]
   val threadDelay: Int = (configJson \ AttributesEnum.THREAD_DELAY.toString).extract[Int]
+  val playgroundEnabled: Boolean = (configJson \ AttributesEnum.PLAYGROUND_ENABLED.toString).extract[Boolean]
+  val corsHeader: String = (configJson \ AttributesEnum.CORS_HEADER.toString).extract[String]
 
   private val captchaConfigJson = (configJson \ "captchas")
   val captchaConfigTransform: JValue = captchaConfigJson transformField {
@@ -65,6 +67,8 @@ class Config(configFilePath: String) {
         (AttributesEnum.CAPTCHA_EXPIRY_TIME_LIMIT.toString -> 5) ~
         (AttributesEnum.THROTTLE.toString -> 1000) ~
         (AttributesEnum.THREAD_DELAY.toString -> 2) ~
+        (AttributesEnum.PLAYGROUND_ENABLED.toString -> true) ~
+        (AttributesEnum.CORS_HEADER.toString -> "") ~
         ("captchas" -> List(
           (
             (AttributesEnum.NAME.toString -> "FilterChallenge") ~

--- a/src/main/scala/lc/server/Server.scala
+++ b/src/main/scala/lc/server/Server.scala
@@ -3,16 +3,21 @@ package lc.server
 import org.json4s.jackson.JsonMethods.parse
 import lc.core.Captcha
 import lc.core.ErrorMessageEnum
-import lc.core.{Parameters, Id, Answer, Error, ByteConvert}
+import lc.core.{Answer, ByteConvert, Error, Id, Parameters}
 import lc.core.Config.formats
 import org.limium.picoserve
-import org.limium.picoserve.Server.ByteResponse
+import org.limium.picoserve.Server.{ByteResponse, ServerBuilder, StringResponse}
 import scala.io.Source
-import org.limium.picoserve.Server.StringResponse
 import java.net.InetSocketAddress
+import java.util
+import scala.jdk.CollectionConverters._
 
-class Server(address: String, port: Int, captcha: Captcha) {
-  val server: picoserve.Server = picoserve.Server
+class Server(address: String, port: Int, captcha: Captcha, playgroundEnabled: Boolean, corsHeader: String) {
+  var headerMap: util.Map[String, util.List[String]] = _
+  if( corsHeader.nonEmpty ) {
+    headerMap = Map("Access-Control-Allow-Origin" -> List(corsHeader).asJava).asJava
+  }
+  val serverBuilder: ServerBuilder = picoserve.Server
     .builder()
     .address(new InetSocketAddress(address, port))
     .backlog(32)
@@ -22,7 +27,7 @@ class Server(address: String, port: Int, captcha: Captcha) {
         val json = parse(request.getBodyString())
         val param = json.extract[Parameters]
         val id = captcha.getChallenge(param)
-        getResponse(id)
+        getResponse(id, headerMap)
       }
     )
     .GET(
@@ -36,7 +41,7 @@ class Server(address: String, port: Int, captcha: Captcha) {
         } else {
           Left(Error(ErrorMessageEnum.INVALID_PARAM.toString + "=> id"))
         }
-        getResponse(result)
+        getResponse(result, headerMap)
       }
     )
     .POST(
@@ -45,10 +50,11 @@ class Server(address: String, port: Int, captcha: Captcha) {
         val json = parse(request.getBodyString())
         val answer = json.extract[Answer]
         val result = captcha.checkAnswer(answer)
-        getResponse(result)
+        getResponse(result, headerMap)
       }
     )
-    .GET(
+  if( playgroundEnabled ) {
+    serverBuilder.GET(
       "/demo/index.html",
       (_) => {
         val resStream = getClass().getResourceAsStream("/index.html")
@@ -56,15 +62,17 @@ class Server(address: String, port: Int, captcha: Captcha) {
         new StringResponse(200, str)
       }
     )
-    .build()
+  }
 
-  private def getResponse(response: Either[Error, ByteConvert]): ByteResponse = {
+  val server: picoserve.Server = serverBuilder.build()
+
+  private def getResponse(response: Either[Error, ByteConvert], responseHeaders: util.Map[String, util.List[String]]): ByteResponse = {
     response match {
       case Right(value) => {
-        new ByteResponse(200, value.toBytes())
+        new ByteResponse(200, value.toBytes(), responseHeaders)
       }
       case Left(value) => {
-        new ByteResponse(500, value.toBytes())
+        new ByteResponse(500, value.toBytes(), responseHeaders)
       }
     }
   }

--- a/tests/debug-config.json
+++ b/tests/debug-config.json
@@ -5,6 +5,8 @@
   "captchaExpiryTimeLimit" : 5,
   "throttle" : 10,
   "threadDelay" : 2,
+  "playgroundEnabled" : false,
+  "corsHeader" : "*",
   "captchas" : [ {
     "name" : "DebugCaptcha",
     "allowedLevels" : [ "debug" ],


### PR DESCRIPTION
- Added configuration to set Access-Control-Allow-Origin header value on responses.
- Added configuration to disable serving the playground webpage.

Continuation of: https://github.com/librecaptcha/lc-core/pull/101