### PR TITLE
Fix for #145: frequent repetition of CAPTCHA challenge

### DIFF
--- a/src/main/scala/lc/core/captchaManager.scala
+++ b/src/main/scala/lc/core/captchaManager.scala
@@ -105,8 +105,8 @@ class CaptchaManager(config: Config, captchaProviders: CaptchaProviders) {
     }
   }
 
-  private def getCount(param: Parameters): Option[Int] = {
-    val countPstmt = Statements.tlStmts.get.countPstmt
+  def getCount(param: Parameters): Option[Int] = {
+    val countPstmt = Statements.tlStmts.get.countForParameterPstmt
     countPstmt.setString(1, param.level)
     countPstmt.setString(2, param.media)
     countPstmt.setString(3, param.input_type)
@@ -123,16 +123,16 @@ class CaptchaManager(config: Config, captchaProviders: CaptchaProviders) {
     if (count == 0) {
       None
     } else {
-    val tokenPstmt = Statements.tlStmts.get.tokenPstmt
-    tokenPstmt.setString(1, param.level)
-    tokenPstmt.setString(2, param.media)
-    tokenPstmt.setString(3, param.input_type)
+      val tokenPstmt = Statements.tlStmts.get.tokenPstmt
+      tokenPstmt.setString(1, param.level)
+      tokenPstmt.setString(2, param.media)
+      tokenPstmt.setString(3, param.input_type)
       tokenPstmt.setInt(4, count)
-    val rs = tokenPstmt.executeQuery()
-    if (rs.next()) {
-      Some(rs.getInt("token"))
-    } else {
-      None
+      val rs = tokenPstmt.executeQuery()
+      if (rs.next()) {
+        Some(rs.getInt("token"))
+      } else {
+        None
       }
     }
   }

--- a/src/main/scala/lc/core/captchaManager.scala
+++ b/src/main/scala/lc/core/captchaManager.scala
@@ -105,16 +105,35 @@ class CaptchaManager(config: Config, captchaProviders: CaptchaProviders) {
     }
   }
 
+  private def getCount(param: Parameters): Option[Int] = {
+    val countPstmt = Statements.tlStmts.get.countPstmt
+    countPstmt.setString(1, param.level)
+    countPstmt.setString(2, param.media)
+    countPstmt.setString(3, param.input_type)
+    val rs = countPstmt.executeQuery()
+    if (rs.next()) {
+      Some(rs.getInt("count"))
+    } else {
+      None
+    }
+  }
+
   private def getToken(param: Parameters): Option[Int] = {
+    val count = getCount(param).getOrElse(0)
+    if (count == 0) {
+      None
+    } else {
     val tokenPstmt = Statements.tlStmts.get.tokenPstmt
     tokenPstmt.setString(1, param.level)
     tokenPstmt.setString(2, param.media)
     tokenPstmt.setString(3, param.input_type)
+      tokenPstmt.setInt(4, count)
     val rs = tokenPstmt.executeQuery()
     if (rs.next()) {
       Some(rs.getInt("token"))
     } else {
       None
+      }
     }
   }
 

--- a/src/main/scala/lc/database/statements.scala
+++ b/src/main/scala/lc/database/statements.scala
@@ -70,6 +70,17 @@ class Statements(dbConn: DBConn, maxAttempts: Int) {
       "WHERE token = ?;"
   )
 
+  val countPstmt: PreparedStatement = dbConn.con.prepareStatement(
+    s"""
+      SELECT count(*) as count
+        FROM challenge
+        WHERE attempted < $maxAttempts AND
+        contentLevel = ? AND
+        contentType = ? AND
+        contentInput = ?
+        """
+  )
+
   val tokenPstmt: PreparedStatement = dbConn.con.prepareStatement(
     s"""
       SELECT token, attempted
@@ -78,7 +89,9 @@ class Statements(dbConn: DBConn, maxAttempts: Int) {
         contentLevel = ? AND
         contentType = ? AND
         contentInput = ?
-        ORDER BY attempted ASC LIMIT 1"""
+        LIMIT 1
+        OFFSET FLOOR(RAND()*?)
+         """
   )
 
   val deleteAnswerPstmt: PreparedStatement = dbConn.con.prepareStatement(

--- a/src/main/scala/lc/database/statements.scala
+++ b/src/main/scala/lc/database/statements.scala
@@ -70,7 +70,7 @@ class Statements(dbConn: DBConn, maxAttempts: Int) {
       "WHERE token = ?;"
   )
 
-  val countPstmt: PreparedStatement = dbConn.con.prepareStatement(
+  val countForParameterPstmt: PreparedStatement = dbConn.con.prepareStatement(
     s"""
       SELECT count(*) as count
         FROM challenge


### PR DESCRIPTION
closes #145 

* In background task, this PR distributes creation of CAPCHAs across each parameter combination, to avoid starvation of any one parameter combination
* When selecting a challenge, this PR picks a random row from the table. This too helps avoid repetition.