### PR TITLE
Point docker-compose.yml to "latest", add "build"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   lc-core:
     container_name: "libre-captcha"
     image: librecaptcha/lc-core:latest
-    # Comment image & uncomment "build" if you intend to build from source
+    # Comment "image" & uncomment "build" if you intend to build from source
     #build: .
     volumes: 
       - "./docker-data:/lc-core/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   lc-core:
     container_name: "libre-captcha"
     image: librecaptcha/lc-core:latest
+    # Comment image & uncomment "build" if you intend to build from source
     #build: .
     volumes: 
       - "./docker-data:/lc-core/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ version: "3.6"
 services:
   lc-core:
     container_name: "libre-captcha"
-    image: librecaptcha/lc-core:1.0.0-stable
+    image: librecaptcha/lc-core:latest
+    #build: .
     volumes: 
       - "./docker-data:/lc-core/data"
     ports: 


### PR DESCRIPTION
More sane to point docker-compose.yml to "latest" instead of ageing version numbers. Also added commented-out build option which should be obvious but still helps.