### PR TITLE
Migrate ServerSpec to ScalaTest and refactor LCFramework for tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).settings(
   libraryDependencies += "com.sksamuel.scrimage" % "scrimage-core" % "4.3.10",
   libraryDependencies += "com.sksamuel.scrimage" % "scrimage-filters" % "4.3.10",
   libraryDependencies += "dev.zio" %% "zio-blocks-schema" % "0.0.31",
-
+  libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test,
 )
 
 Compile / unmanagedResourceDirectories += { baseDirectory.value / "lib" }

--- a/src/main/scala/lc/Main.scala
+++ b/src/main/scala/lc/Main.scala
@@ -5,6 +5,37 @@ import lc.server.Server
 import lc.background.BackgroundTask
 import lc.database.Statements
 
+class LCFramework {
+  private var backgroundTask: Option[BackgroundTask] = None
+  private var server: Option[Server] = None
+
+  def start(configFilePath: String = "data/config.json"): Unit = {
+    val config = new Config(configFilePath)
+    Statements.maxAttempts = config.maxAttempts
+    val captchaProviders = new CaptchaProviders(config = config)
+    val captchaManager = new CaptchaManager(config = config, captchaProviders = captchaProviders)
+    val task = new BackgroundTask(config = config, captchaManager = captchaManager)
+    task.beginThread(delay = config.threadDelay)
+    backgroundTask = Some(task)
+
+    val srv = new Server(
+      address = config.address,
+      port = config.port,
+      captchaManager = captchaManager,
+      playgroundEnabled = config.playgroundEnabled,
+      corsHeader = config.corsHeader
+    )
+    srv.start()
+    server = Some(srv)
+  }
+
+  def stop(): Unit = {
+    println("Shutting down gracefully...")
+    backgroundTask.foreach(_.shutdown())
+    server.foreach(_.stop())
+  }
+}
+
 object LCFramework {
   def main(args: scala.Array[String]): Unit = {
     val configFilePath = if (args.length > 0) {
@@ -12,28 +43,16 @@ object LCFramework {
     } else {
       "data/config.json"
     }
-    val config = new Config(configFilePath)
-    Statements.maxAttempts = config.maxAttempts
-    val captchaProviders = new CaptchaProviders(config = config)
-    val captchaManager = new CaptchaManager(config = config, captchaProviders = captchaProviders)
-    val backgroundTask = new BackgroundTask(config = config, captchaManager = captchaManager)
-    backgroundTask.beginThread(delay = config.threadDelay)
-    val server = new Server(
-      address = config.address,
-      port = config.port,
-      captchaManager = captchaManager,
-      playgroundEnabled = config.playgroundEnabled,
-      corsHeader = config.corsHeader
-    )
+
+    val framework = new LCFramework()
 
     Runtime.getRuntime.addShutdownHook(new Thread {
       override def run(): Unit = {
-        println("Shutting down gracefully...")
-        backgroundTask.shutdown()
+        framework.stop()
       }
     })
 
-    server.start()
+    framework.start(configFilePath)
   }
 }
 

--- a/src/main/scala/lc/server/Server.scala
+++ b/src/main/scala/lc/server/Server.scala
@@ -116,4 +116,9 @@ class Server(
     println("Starting server on " + address + ":" + port)
     server.start()
   }
+
+  def stop(): Unit = {
+    println("Stopping server...")
+    server.stop(0)
+  }
 }

--- a/src/test/scala/lc/ServerSpec.scala
+++ b/src/test/scala/lc/ServerSpec.scala
@@ -1,58 +1,50 @@
 package lc.server
 
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 import java.net.{HttpURLConnection, URL}
 import java.io.{BufferedReader, InputStreamReader, OutputStreamWriter}
 import lc.LCFramework
 
-object ServerSpec {
-  def main(args: Array[String]): Unit = {
-    // Start server before tests in a thread
-    val serverRunnable = new Runnable {
-      override def run(): Unit = {
-        try {
-          LCFramework.main(Array.empty)
-        } catch {
-          case _: InterruptedException => // Expected on shutdown
-        }
-      }
+class ServerSpec extends AnyFunSuite with BeforeAndAfterAll {
+
+  val framework = new LCFramework()
+
+  override def beforeAll(): Unit = {
+    framework.start("tests/debug-config.json")
+    // Give the server a moment to start and generate some captchas
+    Thread.sleep(2000)
+  }
+
+  override def afterAll(): Unit = {
+    framework.stop()
+  }
+
+  test("Server should respond with an id for a valid captcha request") {
+    val url = new URL("http://localhost:8888/v2/captcha")
+    val connection = url.openConnection().asInstanceOf[HttpURLConnection]
+    connection.setRequestMethod("POST")
+    connection.setRequestProperty("Content-Type", "application/json")
+    connection.setDoOutput(true)
+
+    val payload = """{"level":"debug","media":"image/png","input_type":"text","size":"350x100"}"""
+    val out = new OutputStreamWriter(connection.getOutputStream)
+    out.write(payload)
+    out.close()
+
+    val responseCode = connection.getResponseCode
+    assert(responseCode == 200, s"Expected 200 but got $responseCode")
+
+    val in = new BufferedReader(new InputStreamReader(connection.getInputStream))
+    val response = new StringBuilder
+    var line: String = in.readLine()
+    while (line != null) {
+      response.append(line)
+      line = in.readLine()
     }
-    val serverThread = new Thread(serverRunnable)
-    serverThread.start()
+    in.close()
 
-    // Give the server a few seconds to start
-    Thread.sleep(5000)
-
-    try {
-      println("Running ServerSpec Test...")
-      val url = new URL("http://localhost:8888/v2/captcha")
-      val connection = url.openConnection().asInstanceOf[HttpURLConnection]
-      connection.setRequestMethod("POST")
-      connection.setRequestProperty("Content-Type", "application/json")
-      connection.setDoOutput(true)
-
-      val payload = """{"level":"easy","media":"image/png","input_type":"text","size":"350x100"}"""
-      val out = new OutputStreamWriter(connection.getOutputStream)
-      out.write(payload)
-      out.close()
-
-      val responseCode = connection.getResponseCode
-      assert(responseCode == 200, s"Expected 200 but got $responseCode")
-
-      val in = new BufferedReader(new InputStreamReader(connection.getInputStream))
-      val response = new StringBuilder
-      var line: String = in.readLine()
-      while (line != null) {
-        response.append(line)
-        line = in.readLine()
-      }
-      in.close()
-
-      val responseString = response.toString()
-      assert(responseString.contains("id"), "Response did not contain an id")
-      println("Test Passed.")
-    } finally {
-      // Shutdown server without exit so SBT doesn't kill the VM
-      System.exit(0)
-    }
+    val responseString = response.toString()
+    assert(responseString.contains("id"), "Response did not contain an id")
   }
 }


### PR DESCRIPTION
This change resolves the issue of `sbt test` failing to run the test suite by:
1. Adding ScalaTest to the `build.sbt`.
2. Refactoring `LCFramework` and `Server` to support clean startup and shutdown methods for testing.
3. Rewriting `ServerSpec.scala` to use ScalaTest and clean test lifecycle methods, avoiding `System.exit(0)` and blocking operations.
4. Using the `tests/debug-config.json` configuration for deterministic test behaviors.

---
*PR created automatically by Jules for task [5720858097108799958](https://jules.google.com/task/5720858097108799958) started by @hrj*